### PR TITLE
6 feature implement search results page for tags and keyword queries

### DIFF
--- a/floralvault/app/layout.tsx
+++ b/floralvault/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <div className="flex flex-col min-h-screen bg-gradient-to-b from-[#f0e7d8] to-[#f9f3e6]">
+        <div className="flex flex-col min-h-screen bg-gradient-to-r from-[#3A3A38] to-[#151512]">
           <Header />
           <main className="flex-grow">{children}</main>
           <Footer />

--- a/floralvault/app/plant/[slug]/page.tsx
+++ b/floralvault/app/plant/[slug]/page.tsx
@@ -1,0 +1,59 @@
+import { plantData } from "@/mock/plantData";
+import Image from "next/image";
+import { Badge } from "@/components/ui/badge";
+import { notFound } from "next/navigation";
+import { use } from "react";
+
+export default function PlantDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = use(params);
+
+  const plant = plantData.find((p) => p.slug === slug);
+
+  if (!plant) {
+    notFound(); // Optional: Can be a full 404 page
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto py-10 px-4 text-white">
+      <h1 className="text-4xl font-bold mb-2 text-[#81a308]">
+        {plant.common_name || plant.scientific_name}
+      </h1>
+      <h2 className="text-lg italic mb-4 text-gray-400">
+        {plant.scientific_name}
+      </h2>
+
+      <Image
+        src={plant.imageUrl[0]}
+        alt={plant.common_name || plant.scientific_name}
+        width={800}
+        height={400}
+        className="rounded-xl object-cover w-full max-h-[400px] mb-6"
+      />
+
+      <p className="text-base leading-relaxed mb-4">{plant.description}</p>
+
+      <div className="flex flex-wrap gap-2 mb-6">
+        {plant.tags.map((tag, i) => (
+          <Badge
+            key={i}
+            className="text-xs px-2 py-1 bg-[#81a308]/10 text-[#81a308] border border-[#81a308]/30"
+          >
+            {tag}
+          </Badge>
+        ))}
+      </div>
+
+      <div className="text-sm text-gray-400 space-y-1">
+        <p>Origin: {plant.origin}</p>
+        <p>Family: {plant.family}</p>
+        <p>Type: {plant.type}</p>
+        <p>Added: {new Date(plant.createdAt).toLocaleDateString()}</p>
+        <p>Views: {plant.views}</p>
+      </div>
+    </div>
+  );
+}

--- a/floralvault/app/results/page.tsx
+++ b/floralvault/app/results/page.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { redirect } from "next/navigation";
+import ResultsCard from "@/components/cards/ResultsCard";
+
+import { plantData } from "@/mock/plantData";
+import { Plant } from "@/types/plants";
+import GoBackButton from "@/components/ui/GoBackButton";
+
+interface Props {
+  searchParams: {
+    tag?: string;
+    query?: string;
+  };
+}
+
+const ResultsPage = ({ searchParams }: Props) => {
+  const { tag, query } = searchParams;
+
+  if (!tag && !query) {
+    redirect("/");
+  }
+
+  // Filter plants based on tag or query
+  const filteredResults = plantData.filter((plant) => {
+    if (tag) {
+      const lowerTag = tag.toLowerCase();
+      return plant.tags.some((t) => t.toLowerCase() === lowerTag);
+    }
+
+    if (query) {
+      const lowerQuery = query.toLowerCase();
+      return (
+        plant.common_name?.toLowerCase().includes(lowerQuery) ||
+        plant.scientific_name.toLowerCase().includes(lowerQuery) ||
+        plant.description.toLowerCase().includes(lowerQuery) ||
+        plant.origin.toLowerCase().includes(lowerQuery) ||
+        plant.tags.some((t) => t.toLowerCase().includes(lowerQuery))
+      );
+    }
+
+    return false;
+  });
+
+  console.log(filteredResults);
+
+  return (
+    <div className="flex flex-col text-white py-5 px-10 text-2xl font-semibold">
+      {/* Page Heading */}
+      <div className="flex py-5 items-center justify-between">
+        <h1>
+          Searching for:{" "}
+          <span className="italic">
+            {tag?.toUpperCase() || query?.toUpperCase()}
+          </span>
+        </h1>
+
+        <GoBackButton />
+      </div>
+
+      {/* Results cards */}
+
+      {filteredResults.length === 0 ? (
+        <p className="text-center text-base text-muted-foreground py-10">
+          No matching plants found.
+        </p>
+      ) : (
+        <div className="flex flex-col w-full justify-center items-center ">
+          {filteredResults.map((plant: Plant) => (
+            <ResultsCard key={plant.id} plant={plant} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ResultsPage;

--- a/floralvault/components/Header.tsx
+++ b/floralvault/components/Header.tsx
@@ -1,15 +1,59 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Search } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
+import { plantData } from "@/mock/plantData";
+import ResultsCard from "./cards/ResultsCard";
+
 const Header = () => {
   const [searchQuery, setSearchQuery] = React.useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [suggestions, setSuggestions] = useState([]);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
   const router = useRouter();
+
+  // Debounce
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(searchQuery.trim().toLowerCase());
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // Popover
+  useEffect(() => {
+    if (!debouncedQuery) {
+      setSuggestions([]);
+      setIsPopoverOpen(false);
+      return;
+    }
+
+    const filtered = plantData
+      .filter((plant) => {
+        const match =
+          plant.common_name?.toLowerCase().includes(debouncedQuery) ||
+          plant.scientific_name.toLowerCase().includes(debouncedQuery) ||
+          plant.description.toLowerCase().includes(debouncedQuery) ||
+          plant.tags.some((tag) => tag.toLowerCase().includes(debouncedQuery));
+        return match;
+      })
+      .slice(0, 8);
+
+    setSuggestions(filtered);
+    setIsPopoverOpen(filtered.length > 0);
+  }, [debouncedQuery]);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -33,16 +77,32 @@ const Header = () => {
       </h1>
 
       {/* Searchbar */}
-      <form onSubmit={handleSearch} className="relative w-1/2">
-        <Input
-          type="text"
-          placeholder="Search plants, users, tags, or ailments..."
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="pr-10 rounded-2xl bg-white border-0"
-        />
-        <Search className="absolute right-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-5 w-5 cursor-pointer" />
-      </form>
+      <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+        <PopoverTrigger asChild>
+          <form onSubmit={handleSearch} className="relative w-1/2">
+            <Input
+              type="text"
+              placeholder="Search plants, users, tags, or ailments..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pr-10 rounded-2xl bg-white border-0"
+            />
+            <Search className="absolute right-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-5 w-5 cursor-pointer" />
+          </form>
+        </PopoverTrigger>
+        <PopoverContent className="w-[800px] p-2 bg-white">
+          {suggestions.map((plant) => (
+            <div
+              key={plant.id}
+              onClick={() =>
+                router.push(`/results?query=${plant.scientific_name}`)
+              }
+            >
+              <ResultsCard plant={plant} compact />
+            </div>
+          ))}
+        </PopoverContent>
+      </Popover>
 
       {/* Login */}
       <Link href="/login">

--- a/floralvault/components/Header.tsx
+++ b/floralvault/components/Header.tsx
@@ -94,7 +94,7 @@ const Header = () => {
               <div
                 key={plant.id}
                 onClick={() => {
-                  router.push(`/results?query=${plant.scientific_name}`);
+                  router.push(`/plant/${plant.slug}`);
                   setIsPopoverOpen(false);
                 }}
               >

--- a/floralvault/components/Header.tsx
+++ b/floralvault/components/Header.tsx
@@ -49,7 +49,7 @@ const Header = () => {
           plant.tags.some((tag) => tag.toLowerCase().includes(debouncedQuery));
         return match;
       })
-      .slice(0, 8);
+      .slice(0, 5);
 
     setSuggestions(filtered);
     setIsPopoverOpen(filtered.length > 0);
@@ -77,32 +77,33 @@ const Header = () => {
       </h1>
 
       {/* Searchbar */}
-      <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-        <PopoverTrigger asChild>
-          <form onSubmit={handleSearch} className="relative w-1/2">
-            <Input
-              type="text"
-              placeholder="Search plants, users, tags, or ailments..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pr-10 rounded-2xl bg-white border-0"
-            />
-            <Search className="absolute right-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-5 w-5 cursor-pointer" />
-          </form>
-        </PopoverTrigger>
-        <PopoverContent className="w-[800px] p-2 bg-white">
-          {suggestions.map((plant) => (
-            <div
-              key={plant.id}
-              onClick={() =>
-                router.push(`/results?query=${plant.scientific_name}`)
-              }
-            >
-              <ResultsCard plant={plant} compact />
-            </div>
-          ))}
-        </PopoverContent>
-      </Popover>
+
+      <form onSubmit={handleSearch} className="relative w-1/2">
+        <Input
+          type="text"
+          placeholder="Search plants, users, tags, or ailments..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="pr-10 rounded-2xl bg-white border-0"
+        />
+        <Search className="absolute right-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-5 w-5 cursor-pointer" />
+        {/* Popover-style dropdown */}
+        {isPopoverOpen && (
+          <div className="absolute top-full mt-2 z-50 w-full bg-transparent rounded-md shadow-lg p-2 max-h-[800px] overflow-y-hidden">
+            {suggestions.map((plant) => (
+              <div
+                key={plant.id}
+                onClick={() => {
+                  router.push(`/results?query=${plant.scientific_name}`);
+                  setIsPopoverOpen(false);
+                }}
+              >
+                <ResultsCard plant={plant} compact />
+              </div>
+            ))}
+          </div>
+        )}
+      </form>
 
       {/* Login */}
       <Link href="/login">

--- a/floralvault/components/Header.tsx
+++ b/floralvault/components/Header.tsx
@@ -1,31 +1,48 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Search } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 const Header = () => {
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const router = useRouter();
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = searchQuery.trim();
+    if (trimmed) {
+      router.push(`/results?query=${encodeURIComponent(trimmed)}`);
+    }
+  };
+
   return (
-    <div className="flex w-full h-24 px-10 pt-2 items-center justify-between bg-[#f0ece6]">
+    <div className="bg-[#2b2a2a] flex w-full h-24 px-10 pt-2 items-center justify-between ">
       {/* Logo */}
       <h1
-        className="text-4xl font-bold tracking-tight text-foreground cursor-pointer"
+        className="text-4xl text-white font-bold tracking-tight cursor-pointer"
         onClick={() => (window.location.href = "/")}
       >
-        FloralVault
+        <span className="bg-gradient-to-r from-[#dab9df] to-[#e5b3ec] bg-clip-text text-transparent">
+          Floral
+        </span>
+        <span className="text-[#81a308]">Vault</span>
       </h1>
 
       {/* Searchbar */}
-      <div className="relative w-1/2">
+      <form onSubmit={handleSearch} className="relative w-1/2">
         <Input
           type="text"
-          placeholder="Search plants, users, or ailments..."
+          placeholder="Search plants, users, tags, or ailments..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
           className="pr-10 rounded-2xl bg-white border-0"
         />
         <Search className="absolute right-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-5 w-5 cursor-pointer" />
-      </div>
+      </form>
 
       {/* Login */}
       <Link href="/login">

--- a/floralvault/components/cards/ResultsCard.tsx
+++ b/floralvault/components/cards/ResultsCard.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+import Image from "next/image";
+import { Plant } from "@/types/plants";
+import Link from "next/link";
+import { Badge } from "../ui/badge";
+
+interface ResultsCardProps {
+  plant: Plant;
+}
+
+const ResultsCard = ({ plant }: ResultsCardProps) => {
+  return (
+    <div className="flex flex-col sm:flex-row w-full max-w-7xl md:max-h-[260px] gap-2 mb-5 bg-[#2b2a2a] rounded-2xl p-5 cursor-pointer shadow-lg shadow-black/30 hover:shadow-xl transition-shadow duration-200 ease-in-out">
+      {/* Plant Image */}
+      <Image
+        src={plant.imageUrl[0]}
+        alt={plant.common_name}
+        width={200}
+        height={200}
+        className="rounded-xl object-cover h-[200px] w-full sm:w-[200px] sm:h-[200px] md:w-[200px] md:h-[200px] flex-shrink-0"
+      />
+      {/* Plant Description */}
+      <div className="flex flex-col pt-4 md:pt-0 sm:pl-5 overflow-hidden">
+        <div className="flex flex-col gap-1">
+          <h2 className="flex text-2xl text-[#81a308]">{plant.common_name}</h2>
+          <h3 className="text-base">{plant.scientific_name}</h3>
+          <div className="flex flex-wrap gap-1 pb-4 md:pb-4">
+            {plant.tags.slice(0, 3).map((tag, i) => (
+              <Link href={`/results?tag=${encodeURIComponent(tag)}`} key={i}>
+                <Badge
+                  variant="secondary"
+                  className="text-[12px] justify-center px-2 py-0.5 max-w-[80px] truncate hover:bg-[#5f9f6a] hover:rounded-2xl hover:text-white"
+                >
+                  {tag}
+                </Badge>
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-auto">
+          <p className="text-sm line-clamp-3">{plant.description}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResultsCard;

--- a/floralvault/components/cards/ResultsCard.tsx
+++ b/floralvault/components/cards/ResultsCard.tsx
@@ -7,24 +7,38 @@ import { Badge } from "../ui/badge";
 
 interface ResultsCardProps {
   plant: Plant;
+  compact?: boolean;
 }
 
-const ResultsCard = ({ plant }: ResultsCardProps) => {
+const ResultsCard = ({ plant, compact = false }: ResultsCardProps) => {
   return (
-    <div className="flex flex-col sm:flex-row w-full max-w-7xl md:max-h-[260px] gap-2 mb-5 bg-[#2b2a2a] rounded-2xl p-5 cursor-pointer shadow-lg shadow-black/30 hover:shadow-xl transition-shadow duration-200 ease-in-out">
+    <div
+      className={`${
+        compact
+          ? "flex items-center gap-3 p-2 text-white bg-[#2b2a2a] rounded-md hover:bg-[#3a3a3a]"
+          : "flex flex-col sm:flex-row w-full max-w-7xl md:max-h-[260px] gap-2 mb-5 bg-[#2b2a2a] rounded-2xl p-5"
+      } cursor-pointer shadow-lg shadow-black/30 hover:shadow-xl transition-shadow duration-200 ease-in-out`}
+    >
       {/* Plant Image */}
       <Image
         src={plant.imageUrl[0]}
         alt={plant.common_name}
-        width={200}
-        height={200}
-        className="rounded-xl object-cover h-[200px] w-full sm:w-[200px] sm:h-[200px] md:w-[200px] md:h-[200px] flex-shrink-0"
+        width={compact ? 50 : 200}
+        height={compact ? 50 : 200}
+        className={`rounded-xl object-cover flex-shrink-0 ${
+          compact ? "h-[100px] w-[100px]" : "h-[200px] w-full sm:w-[200px]"
+        }`}
       />
       {/* Plant Description */}
       <div className="flex flex-col pt-4 md:pt-0 sm:pl-5 overflow-hidden">
         <div className="flex flex-col gap-1">
-          <h2 className="flex text-2xl text-[#81a308]">{plant.common_name}</h2>
-          <h3 className="text-base">{plant.scientific_name}</h3>
+          <h2 className={`${compact ? "text-sm" : "text-2xl"} text-[#81a308]`}>
+            {plant.common_name}
+          </h2>
+          <h3 className={`${compact ? "text-xs" : "text-base"}`}>
+            {plant.scientific_name}
+          </h3>
+
           <div className="flex flex-wrap gap-1 pb-4 md:pb-4">
             {plant.tags.slice(0, 3).map((tag, i) => (
               <Link href={`/results?tag=${encodeURIComponent(tag)}`} key={i}>
@@ -39,7 +53,7 @@ const ResultsCard = ({ plant }: ResultsCardProps) => {
           </div>
         </div>
 
-        <div className="mt-auto">
+        <div className={`${compact ? "hidden" : "mt-auto"}`}>
           <p className="text-sm line-clamp-3">{plant.description}</p>
         </div>
       </div>

--- a/floralvault/components/cards/ResultsCard.tsx
+++ b/floralvault/components/cards/ResultsCard.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-
 import Image from "next/image";
 import { Plant } from "@/types/plants";
 import Link from "next/link";
@@ -19,43 +18,61 @@ const ResultsCard = ({ plant, compact = false }: ResultsCardProps) => {
           : "flex flex-col sm:flex-row w-full max-w-7xl md:max-h-[260px] gap-2 mb-5 bg-[#2b2a2a] rounded-2xl p-5"
       } cursor-pointer shadow-lg shadow-black/30 hover:shadow-xl transition-shadow duration-200 ease-in-out`}
     >
-      {/* Plant Image */}
-      <Image
-        src={plant.imageUrl[0]}
-        alt={plant.common_name}
-        width={compact ? 50 : 200}
-        height={compact ? 50 : 200}
-        className={`rounded-xl object-cover flex-shrink-0 ${
-          compact ? "h-[100px] w-[100px]" : "h-[200px] w-full sm:w-[200px]"
-        }`}
-      />
-      {/* Plant Description */}
-      <div className="flex flex-col pt-4 md:pt-0 sm:pl-5 overflow-hidden">
-        <div className="flex flex-col gap-1">
-          <h2 className={`${compact ? "text-sm" : "text-2xl"} text-[#81a308]`}>
-            {plant.common_name}
-          </h2>
-          <h3 className={`${compact ? "text-xs" : "text-base"}`}>
-            {plant.scientific_name}
-          </h3>
+      {/* Main clickable content */}
+      <Link
+        href={`/plant/${plant.slug}`}
+        className="flex flex-col sm:flex-row w-full"
+      >
+        {/* Image */}
+        <Image
+          src={plant.imageUrl[0]}
+          alt={plant.common_name}
+          width={compact ? 50 : 200}
+          height={compact ? 50 : 200}
+          className={`rounded-xl object-cover flex-shrink-0 ${
+            compact ? "h-[100px] w-[100px]" : "h-[200px] w-full sm:w-[200px]"
+          }`}
+        />
 
-          <div className="flex flex-wrap gap-1 pb-4 md:pb-4">
-            {plant.tags.slice(0, 3).map((tag, i) => (
-              <Link href={`/results?tag=${encodeURIComponent(tag)}`} key={i}>
-                <Badge
-                  variant="secondary"
-                  className="text-[12px] justify-center px-2 py-0.5 max-w-[80px] truncate hover:bg-[#5f9f6a] hover:rounded-2xl hover:text-white"
-                >
-                  {tag}
-                </Badge>
-              </Link>
-            ))}
+        {/* Text Content */}
+        <div className="flex flex-col pt-4 md:pt-0 sm:pl-5 overflow-hidden w-full">
+          <div className="flex flex-col gap-1 pointer-events-none">
+            <h2
+              className={`${compact ? "text-sm" : "text-2xl"} text-[#81a308]`}
+            >
+              {plant.common_name}
+            </h2>
+            <h3 className={`${compact ? "text-xs" : "text-base"}`}>
+              {plant.scientific_name}
+            </h3>
+          </div>
+
+          <div
+            className={`${compact ? "hidden" : "mt-auto"} pointer-events-none`}
+          >
+            <p className="text-sm line-clamp-3">{plant.description}</p>
           </div>
         </div>
+      </Link>
 
-        <div className={`${compact ? "hidden" : "mt-auto"}`}>
-          <p className="text-sm line-clamp-3">{plant.description}</p>
-        </div>
+      {/* Tags (shown in both compact and full modes, styled differently) */}
+      <div
+        className={
+          compact
+            ? "flex flex-wrap gap-1 mt-1 sm:absolute sm:ml-[115px] sm:mt-10"
+            : "flex flex-wrap gap-1 px-2 sm:pl-1 mt-1 sm:absolute sm:ml-[210px] sm:mt-14"
+        }
+      >
+        {plant.tags.slice(0, 3).map((tag, i) => (
+          <Link href={`/results?tag=${encodeURIComponent(tag)}`} key={i}>
+            <Badge
+              variant="secondary"
+              className="text-[12px] justify-center px-2 py-0.5 max-w-[80px] truncate hover:bg-[#5f9f6a] hover:rounded-2xl hover:text-white"
+            >
+              {tag}
+            </Badge>
+          </Link>
+        ))}
       </div>
     </div>
   );

--- a/floralvault/components/sections/PlantCarousel.tsx
+++ b/floralvault/components/sections/PlantCarousel.tsx
@@ -15,7 +15,7 @@ import Image from "next/image";
 export default function PlantCarousel() {
   const [activeIndex, setActiveIndex] = useState(0);
   const carouselApiRef = useRef<any>(null);
-  const apiRef = useRef<any>(null); // new internal ref
+  const apiRef = useRef<any>(null);
   const [isHovered, setIsHovered] = useState(false);
 
   const updateActiveIndex = () => {
@@ -69,12 +69,15 @@ export default function PlantCarousel() {
                 {plantData.map((plant) => (
                   <CarouselItem
                     key={plant.id}
-                    className="md:basis-1/3 lg:basis-1/5 px-4"
+                    className="md:basis-1/3 lg:basis-1/5 px-4 relative"
                   >
-                    <div className="relative rounded-2xl shadow-lg overflow-hidden transition-transform duration-300 hover:scale-[1.03] cursor-pointer">
+                    {/* Clickable Card */}
+                    <Link
+                      href={`/plant/${plant.slug}`}
+                      className="block relative rounded-2xl shadow-lg overflow-hidden transition-transform duration-300 hover:scale-[1.03] cursor-pointer"
+                    >
                       <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent z-10" />
 
-                      {/* Plant Info */}
                       <Image
                         src={plant.imageUrl[0]}
                         alt={plant.common_name || plant.scientific_name}
@@ -82,7 +85,7 @@ export default function PlantCarousel() {
                         height={320}
                         className="w-full h-80 object-cover rounded-md"
                       />
-                      <div className="absolute inset-0 flex flex-col justify-end p-4 z-20">
+                      <div className="absolute inset-0 flex flex-col justify-end p-4 z-20 bottom-8">
                         <h3 className="text-lg font-bold leading-tight line-clamp-2">
                           {plant.common_name}
                         </h3>
@@ -92,24 +95,24 @@ export default function PlantCarousel() {
                         <p className="text-sm opacity-80 line-clamp-1">
                           {plant.description}
                         </p>
-
-                        {/* Tags */}
-                        <div className="flex gap-1 mt-2">
-                          {plant.tags.slice(0, 3).map((tag, i) => (
-                            <Link
-                              href={`/results?tag=${encodeURIComponent(tag)}`}
-                              key={i}
-                            >
-                              <Badge
-                                variant="secondary"
-                                className="text-[12px] justify-center px-2 py-0.5 max-w-[80px] truncate hover:bg-[#5f9f6a] hover:rounded-2xl hover:text-white"
-                              >
-                                {tag}
-                              </Badge>
-                            </Link>
-                          ))}
-                        </div>
                       </div>
+                    </Link>
+
+                    {/* Tags - separate from the Link */}
+                    <div className="absolute bottom-3 left-6 z-30 flex gap-1 flex-wrap">
+                      {plant.tags.slice(0, 3).map((tag, i) => (
+                        <Link
+                          key={i}
+                          href={`/results?tag=${encodeURIComponent(tag)}`}
+                        >
+                          <Badge
+                            variant="secondary"
+                            className="text-[12px] px-2 py-0.5 max-w-[80px] truncate hover:bg-[#5f9f6a] hover:text-white hover:rounded-2xl"
+                          >
+                            {tag}
+                          </Badge>
+                        </Link>
+                      ))}
                     </div>
                   </CarouselItem>
                 ))}

--- a/floralvault/components/ui/GoBackButton.tsx
+++ b/floralvault/components/ui/GoBackButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "./button";
+
+const GoBackButton = () => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.back();
+
+    // If there isn't enough history, redirect to the home page
+    setTimeout(() => {
+      router.push("/");
+    }, 1000);
+  };
+
+  return (
+    <Button onClick={handleClick} className="hover:bg-accent rounded-2xl">
+      Go Back
+    </Button>
+  );
+};
+
+export default GoBackButton;

--- a/floralvault/components/ui/popover.tsx
+++ b/floralvault/components/ui/popover.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/floralvault/mock/plantData.ts
+++ b/floralvault/mock/plantData.ts
@@ -193,7 +193,7 @@ export const plantData: Plant[] = [
       "https://www.littlerednursery.com/cdn/shop/files/tequilla.jpg?v=1709492819",
     ],
     description:
-      "Blue Agave is used to produce tequila and contains inulin, a prebiotic fiber with potential health benefits.",
+      "Blue Agave (Agave tequilana) is a striking succulent native to the arid regions of Mexico, best known as the plant from which tequila is derived. Characterized by its spiky blue-green leaves that form symmetrical rosettes, this plant thrives in volcanic soils under intense sunlight. Beyond its cultural significance in spirits production, Blue Agave has also drawn attention for its high concentration of inulin, a natural prebiotic fiber believed to aid digestion and improve gut health. Traditionally used in indigenous Mexican medicine, the sap was applied topically for its antiseptic and anti-inflammatory properties, and it continues to be studied for potential metabolic and glycemic control benefits. Blue Agave's resilience to drought and its long maturation period—often 7 to 10 years—underscore its symbolic association with endurance, patience, and transformation. Whether featured ornamentally or harvested agriculturally, this plant represents a convergence of tradition, utility, and ecological adaptation.",
     userId: "user-101",
     tags: ["digestive", "prebiotic", "succulent"],
     views: 176,

--- a/floralvault/package-lock.json
+++ b/floralvault/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^4.1.3",
         "@radix-ui/react-label": "^2.1.2",
+        "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-slot": "^1.1.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -219,6 +220,44 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
       "version": "4.1.3",
@@ -864,11 +903,140 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz",
+      "integrity": "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
       "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
+      "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz",
+      "integrity": "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -886,6 +1054,123 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.6.tgz",
+      "integrity": "sha512-NQouW0x4/GnkFJ/pRqsIS3rM/k97VzKnVb2jB7Gq7VEGPy5g7uNV1ykySFt7eWSp3i2uSGFwaJcvIRJBAHmmFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.2.tgz",
+      "integrity": "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
+      "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -942,6 +1227,114 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1789,6 +2182,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -2381,6 +2786,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -3304,6 +3715,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -5000,6 +5420,75 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
+      "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5893,6 +6382,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {

--- a/floralvault/package.json
+++ b/floralvault/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hookform/resolvers": "^4.1.3",
     "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-slot": "^1.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary  
This PR implements the **Search Results Page** for FloralVault, supporting both **tag-based** and **keyword-based** queries. It improves plant discoverability across the platform and completes the integration between search interactions and navigation.

---

## ✅ What's Included

- [x] Created `ResultsPage` to display search matches from `query` or `tag` parameters
- [x] Implemented full-text matching for `common_name`, `scientific_name`, `description`, `origin`, and `tags`
- [x] Graceful fallback UI for no results (`"No matching plants found"`)
- [x] Refactored `ResultsCard` component with a `compact` prop for reuse in popovers
- [x] Connected homepage carousel and search bar to plant detail pages via `slug` routing
- [x] Added `/plant/[slug]` route to render dynamic plant detail views from mock data
- [x] Included tag badges that link to `/results?tag={tag}` throughout all relevant views
- [x] Popover displays 5–8 live search suggestions beneath header searchbar (with debounce)
- [x] Resolved hydration and params handling issues in slug-based routing

---

## 🧪 Testing Notes

- Validated tag links redirect and correctly filter results
- Confirmed query searches match across multiple fields and handle casing
- Tested `ResultsCard` compact layout in popover and full layout in results
- Verified `slug` routing works from carousel, popover, and search results
- Confirmed graceful fallback for both empty results and slug mismatch
- Responsive tested across mobile and desktop

---

## 📝 Follow-up Work

- Wire search to backend when available (replace `plantData` mock)
- Add support for user and ailment search as data is introduced
- Implement analytics for search popularity and result click-throughs
- Style popover for dark mode and hover states

---

## 🔗 Related Issues

Closes #6  
Builds on components introduced in #5