### PR TITLE
17 feature implement login form to backend login auth endpoint

### DIFF
--- a/floralvault/app/settings/page.tsx
+++ b/floralvault/app/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useUser } from "@/context/UserContext";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -31,15 +31,18 @@ const SettingsPage = () => {
   const [isLoading, setIsLoading] = React.useState(false);
 
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     if (!user) {
       toast.error("You must be logged in to access this page.");
       setTimeout(() => {
-        router.push("/login?unauthorized=true");
-      }, 100); // even 50ms works fine
+        router.push(
+          `/login?unauthorized=true&redirect=${encodeURIComponent(pathname)}`
+        );
+      }, 100);
     }
-  }, [user, router]);
+  }, [user, router, pathname]);
 
   const form = useForm<z.infer<typeof settingsSchema>>({
     resolver: zodResolver(settingsSchema),

--- a/floralvault/components/Header.tsx
+++ b/floralvault/components/Header.tsx
@@ -5,7 +5,7 @@ import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Menu, Search } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import ResultsCard from "./cards/ResultsCard";
 
 import { Plant } from "@/types/plants";
@@ -40,6 +40,7 @@ const Header = () => {
   const { user, logout } = useUser();
 
   const router = useRouter();
+  const pathname = usePathname() || "/";
 
   // Debounce
   useEffect(() => {
@@ -148,8 +149,8 @@ const Header = () => {
                   src={user.avatarUrl || "https://github.com/shadcn.png"}
                 />
                 <AvatarFallback className="bg-white">
-                  {user.firstName.slice(0, 1).toLocaleUpperCase()}
-                  {user.lastName.slice(0, 1).toLocaleUpperCase()}
+                  {user?.firstName?.slice(0, 1).toLocaleUpperCase()}
+                  {user?.lastName?.slice(0, 1).toLocaleUpperCase()}
                 </AvatarFallback>
               </Avatar>
             </DropdownMenuTrigger>
@@ -170,7 +171,7 @@ const Header = () => {
             </DropdownMenuContent>
           </DropdownMenu>
         ) : (
-          <Link href="/login">
+          <Link href={`/login?redirect=${pathname}`}>
             <Button className="bg-primary text-primary-foreground hover:bg-[#756b56] rounded-2xl px-4 py-2 font-semibold transition-colors duration-200 ease-in-out cursor-pointer">
               Login
             </Button>

--- a/floralvault/components/LoginForm.tsx
+++ b/floralvault/components/LoginForm.tsx
@@ -47,9 +47,9 @@ const LoginForm = () => {
     }
   }, [searchParams]);
 
-  const onSubmit = (values: z.infer<typeof formSchema>) => {
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
     setIsLoading(true);
-    const user = loginUser(values);
+    const user = await loginUser(values);
 
     if (!user) {
       setIsLoading(false);
@@ -63,7 +63,9 @@ const LoginForm = () => {
     toast.success(`Welcome back, ${user.firstName || user.username}!`);
     localStorage.setItem("user", JSON.stringify(user));
     setUser(user);
-    router.push("/");
+
+    const redirect = searchParams.get("redirect") || "/";
+    router.push(redirect);
   };
 
   return (

--- a/floralvault/context/UserContext.tsx
+++ b/floralvault/context/UserContext.tsx
@@ -25,6 +25,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const logout = () => {
     setUser(null);
     localStorage.removeItem("user");
+    localStorage.removeItem("token");
     toast.success("Logged out successfully.");
   };
 


### PR DESCRIPTION
## 🧭 Summary

This PR connects the frontend login form to the live backend authentication system at `https://floral-vault-api.onrender.com`. It removes the previous mock-based logic and enables real login functionality using the `POST /api/auth/login` endpoint. Successful login stores the user object and JWT token, while failures display error toasts. Redirect logic was also added to return the user to the page they were on before logging in.

---

## ✅ Acceptance Criteria

- [x] Replace mock `loginUser` with a real fetch-based API request  
- [x] Send `username` and `password` to `POST /api/auth/login`  
- [x] Store returned `token` and `user` in `localStorage`  
- [x] Display success or failure toasts  
- [x] Update app state to reflect logged-in user  
- [x] Add redirect functionality to return user to previous page after login  

---

## 🧩 Additional Changes

- Added additional functionality to remove `token` from `localStorage` on logout

---

## 🧪 Testing Notes

- Use valid and invalid credentials and confirm expected behavior  
- Check that token and user are stored in `localStorage`  
- Verify login toasts appear correctly  
- Confirm user is redirected after login (when `redirect` param is present)  

---

## 📝 Follow-up Work

- Implement `registerUser()` with backend integration  
- Use stored token to fetch session via `/api/users/me`  
- Begin protecting frontend routes based on login state  

---

## 🔗 Related Files

- `lib/utils.ts` – `loginUser()` logic  
- `components/LoginForm.tsx` – login form logic and submission  
- `context/UserContext.tsx` – global auth state  

---

## 🛠️ Related Issues

Closes #17 – [Feature] Implement login form to backend login auth endpoint
